### PR TITLE
Update baseimage to debian:9.4

### DIFF
--- a/backend-dummy/Dockerfile
+++ b/backend-dummy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.4
+FROM debian:9.4
 LABEL maintainer "Etsuji Nakai <enakai@google.com>"
 ENV REFRESHED_AT 2017/02/28
 

--- a/backend-smart/Dockerfile
+++ b/backend-smart/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.4
+FROM debian:9.4
 LABEL maintainer "Etsuji Nakai <enakai@google.com>"
 ENV REFRESHED_AT 2017/02/28
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.4
+FROM debian:9.4
 LABEL maintainer "Etsuji Nakai <enakai@google.com>"
 ENV REFRESHED_AT 2017/02/28
 


### PR DESCRIPTION
This is necessary since Installing gcloud package may fail with debian:8.4 now.
